### PR TITLE
Add DietlyAPI to Food Databases

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Databases and apis that contain nutrition information.
 
 - [USDA FoodData Central](https://fdc.nal.usda.gov/) - Free government database and api for nutrition information on a variety of branded and basic foods.
 - [OpenFoodFacts](https://world.openfoodfacts.org/) - Free crowdsourced database of food products.
+- [DietlyAPI](https://www.getdietly.com/api) - Food & nutrition API with 4.2M+ foods, macros, micronutrients and barcode lookup; free tier with instant key.
 - [ESHA](https://esha.com/products/nutrition-database-api/) - Nutrition database API.
 - [Zestful](https://zestfuldata.com/) - API to turn plain recipe strings into structured JSON.
 - [Spoonacular](https://spoonacular.com/) - Nutrition and recipe API.


### PR DESCRIPTION
Adds [DietlyAPI](https://www.getdietly.com/api) — a food & nutrition API with 4.2M+ foods (macros, micronutrients, barcode lookup), built on normalized/deduped Open Food Facts + community data with confidence-ranked search. Free tier with instant self-serve API key, no card required.